### PR TITLE
full model multi gpu

### DIFF
--- a/src/lxrt/entry.py
+++ b/src/lxrt/entry.py
@@ -20,55 +20,7 @@ import os
 import torch
 import torch.nn as nn
 
-from lxrt.tokenization import BertTokenizer
 from lxrt.modeling import LXRTFeatureExtraction as VisualBertForLXRFeature, VISUAL_CONFIG
-
-
-class InputFeatures(object):
-    """A single set of features of data."""
-
-    def __init__(self, input_ids, input_mask, segment_ids):
-        self.input_ids = input_ids
-        self.input_mask = input_mask
-        self.segment_ids = segment_ids
-
-
-def convert_sents_to_features(sents, max_seq_length, tokenizer):
-    """Loads a data file into a list of `InputBatch`s."""
-
-    features = []
-    for (i, sent) in enumerate(sents):
-        tokens_a = tokenizer.tokenize(sent.strip())
-
-        # Account for [CLS] and [SEP] with "- 2"
-        if len(tokens_a) > max_seq_length - 2:
-            tokens_a = tokens_a[:(max_seq_length - 2)]
-        
-        # Keep segment id which allows loading BERT-weights.
-        tokens = ["[CLS]"] + tokens_a + ["[SEP]"]
-        segment_ids = [0] * len(tokens)
-
-        input_ids = tokenizer.convert_tokens_to_ids(tokens)
-
-        # The mask has 1 for real tokens and 0 for padding tokens. Only real
-        # tokens are attended to.
-        input_mask = [1] * len(input_ids)
-
-        # Zero-pad up to the sequence length.
-        padding = [0] * (max_seq_length - len(input_ids))
-        input_ids += padding
-        input_mask += padding
-        segment_ids += padding
-
-        assert len(input_ids) == max_seq_length
-        assert len(input_mask) == max_seq_length
-        assert len(segment_ids) == max_seq_length
-
-        features.append(
-                InputFeatures(input_ids=input_ids,
-                              input_mask=input_mask,
-                              segment_ids=segment_ids))
-    return features
 
 
 def set_visual_config(args):
@@ -82,12 +34,6 @@ class LXRTEncoder(nn.Module):
         super().__init__()
         self.max_seq_length = max_seq_length
         set_visual_config(args)
-
-        # Using the bert tokenizer
-        self.tokenizer = BertTokenizer.from_pretrained(
-            "bert-base-uncased",
-            do_lower_case=True
-        )
 
         # Build LXRT Model
         self.model = VisualBertForLXRFeature.from_pretrained(
@@ -106,14 +52,7 @@ class LXRTEncoder(nn.Module):
     def dim(self):
         return 768
 
-    def forward(self, sents, feats, visual_attention_mask=None):
-        train_features = convert_sents_to_features(
-            sents, self.max_seq_length, self.tokenizer)
-
-        input_ids = torch.tensor([f.input_ids for f in train_features], dtype=torch.long).cuda()
-        input_mask = torch.tensor([f.input_mask for f in train_features], dtype=torch.long).cuda()
-        segment_ids = torch.tensor([f.segment_ids for f in train_features], dtype=torch.long).cuda()
-
+    def forward(self, input_ids, segment_ids, input_mask, feats, visual_attention_mask=None):
         output = self.model(input_ids, segment_ids, input_mask,
                             visual_feats=feats,
                             visual_attention_mask=visual_attention_mask)

--- a/src/param.py
+++ b/src/param.py
@@ -40,6 +40,7 @@ def parse_args():
 
     # Training Hyper-parameters
     parser.add_argument('--batchSize', dest='batch_size', type=int, default=256)
+    parser.add_argument('--batchSizeVal', dest='batch_size_val', help='batch size on validation', type=int, default=1024)
     parser.add_argument('--optim', default='bert')
     parser.add_argument('--lr', type=float, default=1e-4)
     parser.add_argument('--epochs', type=int, default=10)

--- a/src/tasks/vqa.py
+++ b/src/tasks/vqa.py
@@ -57,7 +57,8 @@ class VQA:
         # GPU options
         self.model = self.model.cuda()
         if args.multiGPU:
-            self.model.lxrt_encoder.multi_gpu()
+            self.model = nn.DataParallel(self.model)
+            #self.model.lxrt_encoder.multi_gpu()
 
         # Loss and Optimizer
         self.bce_loss = nn.BCEWithLogitsLoss()

--- a/src/tasks/vqa.py
+++ b/src/tasks/vqa.py
@@ -85,13 +85,14 @@ class VQA:
         best_valid = 0.
         for epoch in range(args.epochs):
             quesid2ans = {}
-            for i, (ques_id, feats, boxes, sent, target) in iter_wrapper(enumerate(loader)):
+            for i, (ques_id, feats, boxes, input_ids, segment_ids, input_mask, target) in iter_wrapper(enumerate(loader)):
 
                 self.model.train()
                 self.optim.zero_grad()
 
                 feats, boxes, target = feats.cuda(), boxes.cuda(), target.cuda()
-                logit = self.model(feats, boxes, sent)
+                input_ids, segment_ids, input_mask = input_ids.cuda(), segment_ids.cuda(), input_mask.cuda()
+                logit = self.model(input_ids, segment_ids, input_mask, feats, boxes)
                 assert logit.dim() == target.dim() == 2
                 loss = self.bce_loss(logit, target)
                 loss = loss * logit.size(1)
@@ -136,10 +137,11 @@ class VQA:
         dset, loader, evaluator = eval_tuple
         quesid2ans = {}
         for i, datum_tuple in enumerate(loader):
-            ques_id, feats, boxes, sent = datum_tuple[:4]   # Avoid seeing ground truth
+            ques_id, feats, boxes, input_ids, segment_ids, input_mask = datum_tuple[:6]   # Avoid seeing ground truth
             with torch.no_grad():
                 feats, boxes = feats.cuda(), boxes.cuda()
-                logit = self.model(feats, boxes, sent)
+                input_ids, segment_ids, input_mask = input_ids.cuda(), segment_ids.cuda(), input_mask.cuda()
+                logit = self.model(input_ids, segment_ids, input_mask, feats, boxes)
                 score, label = logit.max(1)
                 for qid, l in zip(ques_id, label.cpu().numpy()):
                     ans = dset.label2ans[l]
@@ -157,7 +159,7 @@ class VQA:
     def oracle_score(data_tuple):
         dset, loader, evaluator = data_tuple
         quesid2ans = {}
-        for i, (ques_id, feats, boxes, sent, target) in enumerate(loader):
+        for i, (ques_id, feats, boxes, input_ids, segment_ids, input_mask, target) in enumerate(loader):
             _, label = target.max(1)
             for qid, l in zip(ques_id, label.cpu().numpy()):
                 ans = dset.label2ans[l]

--- a/src/tasks/vqa.py
+++ b/src/tasks/vqa.py
@@ -57,8 +57,8 @@ class VQA:
         # GPU options
         self.model = self.model.cuda()
         if args.multiGPU:
-            self.model = nn.DataParallel(self.model)
-            #self.model.lxrt_encoder.multi_gpu()
+            #self.model = nn.DataParallel(self.model)
+            self.model.multi_gpu()
 
         # Loss and Optimizer
         self.bce_loss = nn.BCEWithLogitsLoss()

--- a/src/tasks/vqa_data.py
+++ b/src/tasks/vqa_data.py
@@ -11,7 +11,6 @@ from torch.utils.data import Dataset
 
 from param import args
 from utils import load_obj_tsv
-from lxrt.tokenization import BertTokenizer
 
 # Load part of the dataset for fast checking.
 # Notice that here is the number of images instead of the number of data,
@@ -132,10 +131,9 @@ FIELDNAMES = ["img_id", "img_h", "img_w", "objects_id", "objects_conf",
 FIELDNAMES would be keys in the dict returned by load_obj_tsv.
 """
 class VQATorchDataset(Dataset):
-    def __init__(self, dataset: VQADataset, tokenizer: BertTokenizer):
+    def __init__(self, dataset: VQADataset):
         super().__init__()
         self.raw_dataset = dataset
-        self.tokenizer = tokenizer
 
         if args.tiny:
             topk = TINY_IMG_NUM
@@ -191,7 +189,7 @@ class VQATorchDataset(Dataset):
         boxes[:, (1, 3)] /= img_h
         np.testing.assert_array_less(boxes, 1+1e-5)
         np.testing.assert_array_less(-boxes, 0+1e-5)
-        input_ids, input_masks, segment_ids = convert_sents_to_features(ques, 20, self.tokenizer)
+        #input_ids, input_masks, segment_ids = convert_sents_to_features(ques, 20, self.tokenizer)
 
         # Provide label (target)
         if 'label' in datum:
@@ -199,9 +197,9 @@ class VQATorchDataset(Dataset):
             target = torch.zeros(self.raw_dataset.num_answers)
             for ans, score in label.items():
                 target[self.raw_dataset.ans2label[ans]] = score
-            return ques_id, feats, boxes, input_ids, input_masks, segment_ids, target
+            return ques_id, feats, boxes, ques, target
         else:
-            return ques_id, feats, boxes, input_ids, input_masks, segment_ids
+            return ques_id, feats, boxes, ques
 
 
 class VQAEvaluator:

--- a/src/tasks/vqa_model.py
+++ b/src/tasks/vqa_model.py
@@ -12,7 +12,7 @@ MAX_VQA_LENGTH = 20
 
 
 class VQAModel(nn.Module):
-    def __init__(self, num_answers):
+    def __init__(self, num_answers, loss=None):
         super().__init__()
         
         # Build LXRT encoder
@@ -30,8 +30,9 @@ class VQAModel(nn.Module):
             nn.Linear(hid_dim * 2, num_answers)
         )
         self.logit_fc.apply(self.lxrt_encoder.model.init_bert_weights)
+        self.loss = loss
 
-    def forward(self, input_ids, segment_ids, input_mask, feat, pos):
+    def forward(self, input_ids, segment_ids, input_mask, feat, pos, target=None):
         """
         b -- batch_size, o -- object_number, f -- visual_feature_size
 
@@ -43,8 +44,9 @@ class VQAModel(nn.Module):
         """
         x = self.lxrt_encoder(input_ids, segment_ids, input_mask, (feat, pos))
         logit = self.logit_fc(x)
-
-        return logit
+        if target is None or self.loss is None:
+            return logit
+        return logit, self.loss(logit, target)
 
     def multi_gpu(self):
         self.lxrt_encoder.multi_gpu()

--- a/src/tasks/vqa_model.py
+++ b/src/tasks/vqa_model.py
@@ -31,7 +31,7 @@ class VQAModel(nn.Module):
         )
         self.logit_fc.apply(self.lxrt_encoder.model.init_bert_weights)
 
-    def forward(self, feat, pos, sent):
+    def forward(self, input_ids, segment_ids, input_mask, feat, pos):
         """
         b -- batch_size, o -- object_number, f -- visual_feature_size
 
@@ -41,7 +41,7 @@ class VQAModel(nn.Module):
         :param leng: (b,) Type -- int numpy array
         :return: (b, num_answer) The logit of each answers.
         """
-        x = self.lxrt_encoder(sent, (feat, pos))
+        x = self.lxrt_encoder(input_ids, segment_ids, input_mask, (feat, pos))
         logit = self.logit_fc(x)
 
         return logit

--- a/src/tasks/vqa_model.py
+++ b/src/tasks/vqa_model.py
@@ -46,4 +46,6 @@ class VQAModel(nn.Module):
 
         return logit
 
-
+    def multi_gpu(self):
+        self.lxrt_encoder.multi_gpu()
+        self.logit_fc = nn.DataParallel(self.logit_fc)


### PR DESCRIPTION
in standard pipeline only encoder paralleled. It leads to non equal GPU utilization (6 GB on first GPU, and 2GB for 2-4)

For increasing data loader num workers, there is command line argument `--numWorkers` (default 0)

@grib0ed0v please take a look
